### PR TITLE
fix: override gray background of dark-reader extensions

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,3 +1,7 @@
+:root {
+	background-color: #000 !important;
+}
+
 body {
 	background-color: #000
 }


### PR DESCRIPTION
When using Dark reader browser extension, the website is not entirely black - gray border is added around `console` element. Overriding color of root in css fixes this issue.